### PR TITLE
Fall back to first root node

### DIFF
--- a/src/Our.Umbraco.Extensions.Routing/RootNodeByDomainRouteHandler.cs
+++ b/src/Our.Umbraco.Extensions.Routing/RootNodeByDomainRouteHandler.cs
@@ -43,7 +43,8 @@ namespace Our.Umbraco.Extensions.Routing
                 }
                 else
                 {
-                    return null;
+                    // No domains are configured, use the first root node which can be found
+                    return _umbracoContextFactory.EnsureUmbracoContext().UmbracoContext.Content.GetAtRoot().FirstOrDefault();
                 }
             }
 

--- a/src/Our.Umbraco.Extensions.Routing/RootNodeByDomainRouteHandler.cs
+++ b/src/Our.Umbraco.Extensions.Routing/RootNodeByDomainRouteHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Web.Routing;
 
 using Our.Umbraco.Extensions.Routing.Helpers;
@@ -29,7 +30,6 @@ namespace Our.Umbraco.Extensions.Routing
                 var forwardedHost = requestContext.HttpContext.Request.Headers.Get("X-Forwarded-Host");
                 var isHttps = requestContext.HttpContext.Request.Headers.Get("X-Forwarded-Proto")
                     .InvariantEquals("HTTPS");
-
 
                 var forwardedUriString = isHttps ? "https" : "http";
                 forwardedUriString += $"://{forwardedHost}";


### PR DESCRIPTION
The routing component is not working as mentioned in a few issues on your repo's if no domain is linked.

I suggest a fallback to the first rootnode if no domain can be found.

fixes https://github.com/callumbwhyte/friendly-sitemap/issues/12
fixes https://github.com/callumbwhyte/friendly-robots/issues/4
fixes https://github.com/callumbwhyte/friendly-sitemap/issues/9
